### PR TITLE
(RE) Implement new lbry's usage changes and use thumbnail file instead of url

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,7 +35,7 @@ repos:
     rev: 3.8.3
     hooks:
     -   id: flake8
-        args: [--ignore=E501, --max-line-length=88]
+        args: [--max-line-length=88]
 -   repo: https://github.com/pre-commit/mirrors-mypy
     rev: v0.782
     hooks:

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ the edges and neither well thought nor complete.
 
 - Fill [config.toml] before running the script
 - Provided folder path must be an absolute one
-- Available thumbnail url
 - Song titles must match the format `{number} - {title}.{format}`
+- If there's a thumbnail named after the album, it will be used
 - Folder structure as follows
 
 > Files should be in a folder which is named after the album, inside a
@@ -43,7 +43,7 @@ the edges and neither well thought nor complete.
 
 - Create a virtual enviroment and activate it
 
-  ```sh
+  ```text
   python3 -m virtualenv .venv && source .venv/bin/activate
   ```
 
@@ -63,11 +63,19 @@ the edges and neither well thought nor complete.
 
 ### Changelog
 
+- October 8, 2020:
+  - Fix outdated selectors
+  - Account for lbry's new upload confirmation popup
+  - Use thumbnail file inside the album folder instead of a url
+  - Delete `thumbnail_url` from upload section in config
+  - Add `thumbnail_format` to files section in config
+  - Don't use `-` separator between song number and name
+
 - September 14, 2020:
   - Basic validation for `language` and `license_type`
 
 - September 10, 2020:
-  - Closing the `success` popup is more reliable
+  - Closing the success popup is more reliable
   - Selecting files is more reliable
   - Fix outdated selectors
   - Use ASCII in claim name

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ the edges and neither well thought nor complete.
   pip install -r requirements.txt
   ```
 
-- Fill `config.toml`
+- Fill [config.toml]
 
 - Run the script
 

--- a/batch_upload.py
+++ b/batch_upload.py
@@ -72,7 +72,7 @@ class LoginPage(BasePage):
         return self.driver.find_element_by_css_selector('#password')
 
     def _signin_button(self):
-        return self.driver.find_element_by_css_selector('[aria-label="Sign In"]')
+        return self.driver.find_element_by_css_selector('[aria-label="Log In"]')
 
     def _continue_button(self):
         return self.driver.find_element_by_css_selector('[aria-label="Continue"]')
@@ -102,7 +102,10 @@ def close_success_popup(func):
 
 class UploadPage(BasePage):
     def _file_button(self):
-        return self.driver.find_element_by_css_selector('[aria-label="Browse"]')
+        return self.driver.find_element_by_xpath(
+            '//*[@id="app"]/div/div[1]/main/div/section[1]/'
+            'div[2]/fieldset-section[2]/input-submit/button'
+        )
 
     def _title(self):
         return self.driver.find_element_by_css_selector('#content_title')

--- a/batch_upload.py
+++ b/batch_upload.py
@@ -27,7 +27,6 @@ class Config:
 
     def _parse_upload_fields(self, upload_config):
         self.description = upload_config['description']
-        self.thumbnail_url = upload_config['thumbnail_url']
         self.tags = upload_config['tags']
         self.channel = upload_config['channel']
         self.deposit = upload_config['deposit']
@@ -156,6 +155,16 @@ class UploadPage(BasePage):
     def _publish_button(self):
         return self.driver.find_element_by_css_selector('[aria-label="Upload"]')
 
+    def _skip_preview_checkbox(self):
+        return self.driver.find_element_by_xpath(
+            '/html/body/div[4]/div/div/form/section/div[3]/div[2]/label'
+        )
+
+    def _upload_button(self):
+        return self.driver.find_element_by_xpath(
+            '/html/body/div[4]/div/div/form/section/div[3]/div[1]/button[1]'
+        )
+
     def _publish_next_button(self):
         return self.driver.find_element_by_css_selector('a[href="/$/upload"]')
 
@@ -248,6 +257,10 @@ class UploadPage(BasePage):
     def publish(self):
         self._publish_button().click()
 
+    def confirm_upload(self):
+        self._skip_preview_checkbox().click()
+        self._upload_button().click()
+
     @close_success_popup
     def continue_publishing(self):
         self._publish_next_button().click()
@@ -282,6 +295,8 @@ class UploadPage(BasePage):
             self.fill_license()
 
         self.publish()
+        if first_song:
+            self.confirm_upload()
         time.sleep(5)  # NOTE: so they finish uploading in order
 
 

--- a/batch_upload.py
+++ b/batch_upload.py
@@ -339,8 +339,9 @@ def get_sanitized_claim_name(song_name):
 def get_song_data(folder_path, song_name):  # TODO: move to `upload_page`
     path_head, album = os.path.split(folder_path)
     _, artist = os.path.split(path_head)
+    title = os.path.splitext(song_name)[0].replace(' -', '')
     # FIXME: `upload_title` can contain multiple `-`
-    upload_title = f'{os.path.splitext(song_name)[0]} - {album} - {artist}'
+    upload_title = f'{title} - {album} - {artist}'
     claim_name = unidecode.unidecode(
         os.path.splitext(get_sanitized_claim_name(song_name))[0].replace(' ', '-')
     )

--- a/config.toml
+++ b/config.toml
@@ -5,6 +5,7 @@ password = ""
 [files]
 folder_path = "/home/bledy/Music/Red Hot Chili Peppers/Californication"
 audio_format = ".flac"
+thumbnail_format = ".jpg"
 excluded = [
     "album_info.txt",
 ]
@@ -12,12 +13,10 @@ excluded = [
 [upload]
 description = """
 """
-thumbnail_url = "https://thumbs.spee.ch/view/4/86562ae3-125d-4cf6-8ca6-a2a83b7c2d78.jpg"
 tags = [
     "music",
     "art",
     "flac",
-    "rhcp",
     "red hot chili peppers",
 ]
 channel = "@bLeDy"


### PR DESCRIPTION
- Fix outdated selectors
- Account for lbry's new upload confirmation popup
- Use thumbnail file inside the album folder instead of a url
- Delete `thumbnail_url` from upload section in config
- Add `thumbnail_format` to files section in config
- Don't use `-` separator between song number and name